### PR TITLE
Release/0.1.2

### DIFF
--- a/purger/purger.py
+++ b/purger/purger.py
@@ -160,7 +160,7 @@ def sort_holding_tank(purger_dict, today, logger):
         if file_date.month == today.month and file_date.day == 1:
             check_processing_type(nc_file, file_mod, today, purger_dict)
         # Refined files for previous months
-        elif file_date.month < today.month:
+        elif file_date.year < today.year or file_date.month < today.month:
             sort_refined_holding(nc_file, today, file_mod, purger_dict)
         # Quicklook files for current month
         elif file_date.month == today.month:

--- a/terraform/purger-lambda.tf
+++ b/terraform/purger-lambda.tf
@@ -22,6 +22,7 @@ resource "aws_s3_object" "aws_s3_bucket_job_configuration" {
   key                    = "config/purger.json"
   server_side_encryption = "aws:kms"
   source                 = "purger.json"
+  etag                   = filemd5("purger.json")
 }
 
 # AWS Lambda role and policy

--- a/terraform/purger.json
+++ b/terraform/purger.json
@@ -50,10 +50,16 @@
             "glob_ops": ["MODIS_AQUA_L2_SST_OBPG_QUICKLOOK/*", "MODIS_TERRA_L2_SST_OBPG_QUICKLOOK/*", "VIIRS_L2_SST_OBPG_QUICKLOOK/*"],
             "action": "delete"    
         },
-        "downloads_refined": {
+        "downloads_refined_modis": {
             "path": "/mnt/data/combiner/downloads",
             "threshold": 1824,
-            "glob_ops": ["MODIS_AQUA_L2_SST_OBPG_REFINED/*", "MODIS_TERRA_L2_SST_OBPG_REFINED/*", "VIIRS_L2_SST_OBPG_REFINED/*"],
+            "glob_ops": ["MODIS_AQUA_L2_SST_OBPG_REFINED/*", "MODIS_TERRA_L2_SST_OBPG_REFINED/*"],
+            "action": "delete"    
+        },
+        "downloads_refined_viirs": {
+            "path": "/mnt/data/combiner/downloads",
+            "threshold": 72,
+            "glob_ops": ["VIIRS_L2_SST_OBPG_REFINED/*"],
             "action": "delete"    
         },
         "holding_tank_quicklook": {
@@ -62,10 +68,16 @@
             "glob_ops": ["*"],
             "action": "delete"    
         },
-        "holding_tank_refined": {
+        "holding_tank_refined_modis": {
             "path": "/mnt/data/processor/input/holding_tank",
             "threshold": 1824,
-            "glob_ops": ["*"],
+            "glob_ops": ["*MODIS*"],
+            "action": "delete"    
+        },
+        "holding_tank_refined_viirs": {
+            "path": "/mnt/data/processor/input/holding_tank",
+            "threshold": 72,
+            "glob_ops": ["*VIIRS*"],
             "action": "delete"    
         },
         "jobs": {


### PR DESCRIPTION
### Description

Cloud-Generate Purger version 0.1.2

**Scope:**

Modify the purger so it deletes refined VIIRS data after 72 hours.

### Overview of work done

Documentation: https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+Workflow+Modifications#GenerateCloudWorkflowModifications-ModifythepurgersoitdeletesrefinedVIIRSdataafter72hours 

### Overview of verification done

SIT & UAT Test Results: https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+Workflow+Modifications#GenerateCloudWorkflowModifications-ModifythepurgersoitdeletesrefinedVIIRSdataafter72hours 